### PR TITLE
feat: use VP details instead details html tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .vercel
 showcase/*.md
 !showcase/index.md
+.idea/

--- a/.vitepress/data/repository.json
+++ b/.vitepress/data/repository.json
@@ -2,7 +2,7 @@
   {
     "name": "unplugin-vue-components",
     "stargazers": {
-      "totalCount": 3360
+      "totalCount": 3361
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",
@@ -13,12 +13,12 @@
       "name": "TypeScript",
       "color": "#3178c6"
     },
-    "forkCount": 324
+    "forkCount": 325
   },
   {
     "name": "unplugin-icons",
     "stargazers": {
-      "totalCount": 3288
+      "totalCount": 3294
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",
@@ -34,7 +34,7 @@
   {
     "name": "unplugin-auto-import",
     "stargazers": {
-      "totalCount": 2742
+      "totalCount": 2750
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",
@@ -66,7 +66,7 @@
   {
     "name": "unplugin-vue-markdown",
     "stargazers": {
-      "totalCount": 427
+      "totalCount": 428
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",
@@ -98,7 +98,7 @@
   {
     "name": "unplugin-turbo-console",
     "stargazers": {
-      "totalCount": 213
+      "totalCount": 215
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",
@@ -146,7 +146,7 @@
   {
     "name": "unplugin-vue",
     "stargazers": {
-      "totalCount": 126
+      "totalCount": 127
     },
     "owner": {
       "avatarUrl": "https://avatars.githubusercontent.com/u/143585159?v=4",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR includes:
- convert html details to VP details
- fix links to source code, using `https://raw.githubusercontent.com`  and should use `https://github.com/unplugin/${name}/tree/...`: click on any source code link, for example click on the unplugin-auto-import playground link shown in the screenshot below
- include Jetbrains `.idea` folder to `.gitignore`

![imagen](https://github.com/unplugin/docs/assets/6311119/78813ebc-afd6-4142-a339-1100596e0c3c)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
